### PR TITLE
fix the bug about open cv type error in line function.

### DIFF
--- a/datasets/face_dataset.py
+++ b/datasets/face_dataset.py
@@ -302,7 +302,9 @@ class FaceDataset(BaseDataset):
         num = int(shoulder_points.shape[0] / 2)
         for i in range(2):
             for j in range(num - 1):
-                img = cv2.line(img, tuple(shoulder_points[i * num + j]), tuple(shoulder_points[i * num + j + 1]), 255, 2)  # BGR
+                pt1 = [int(flt) for flt in shoulder_points[i * num + j]]
+                pt2 = [int(flt) for flt in shoulder_points[i * num + j + 1]]
+                img = cv2.line(img, tuple(pt1), tuple(pt2), 255, 2)  # BGR
         
         return img
 
@@ -314,8 +316,10 @@ class FaceDataset(BaseDataset):
         for edge_list in self.part_list:
             for edge in edge_list:
                 for i in range(len(edge)-1):
-                    im_edges = cv2.line(im_edges, tuple(keypoints[edge[i]]), tuple(keypoints[edge[i+1]]), 255, 2)
-            
+                    pt1 = [int(flt) for flt in keypoints[edge[i]]]
+                    pt2 = [int(flt) for flt in keypoints[edge[i + 1]]]
+                    im_edges = cv2.line(im_edges, tuple(pt1), tuple(pt2), 255, 2)
+
         return im_edges
 
 


### PR DESCRIPTION
For the latest version of OpenCV, the line function make the parameter must be 'Int' type.  which here got float list.
So we will got this error:

Traceback (most recent call last):
  File "demo.py", line 262, in <module>
    current_pred_feature_map = facedataset.dataset.get_data_test_mode(pred_landmarks[ind],
  File "D:\codebase\pydl\cv\73_LiveSpeechPortraits-main\datasets\face_dataset.py", line 280, in get_data_test_mode
    feature_map = torch.from_numpy(self.get_feature_image(landmarks, (self.opt.loadSize, self.opt.loadSize), shoulder, pad)[np.newaxis, :].astype(np.float32)/255.)
  File "D:\codebase\pydl\cv\73_LiveSpeechPortraits-main\datasets\face_dataset.py", line 295, in get_feature_image
    im_edges = self.draw_shoulder_points(im_edges, shoulders)
  File "D:\codebase\pydl\cv\73_LiveSpeechPortraits-main\datasets\face_dataset.py", line 305, in draw_shoulder_points
    img = cv2.line(img, tuple(shoulder_points[i * num + j]), tuple(shoulder_points[i * num + j + 1]), 255, 2)  # BGR
cv2.error: OpenCV(4.5.5) :-1: error: (-5:Bad argument) in function 'line'
> Overload resolution failed:
>  - Can't parse 'pt1'. Sequence item with index 0 has a wrong type
>  - Can't parse 'pt1'. Sequence item with index 0 has a wrong type

So convert the float list to a int list to fix this error. Pass test in torch1.7 & opencv 4.5.5.