### PR TITLE
Explicitly added map_location 👌

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -147,7 +147,7 @@ if __name__ == '__main__':
                             config['model_params']['APC']['hidden_size'],
                             config['model_params']['APC']['num_layers'],
                             config['model_params']['APC']['residual'])
-    APC_model.load_state_dict(torch.load(config['model_params']['APC']['ckp_path']), strict=False)
+    APC_model.load_state_dict(torch.load(config['model_params']['APC']['ckp_path'], map_location=device), strict=False)
     if opt.device == 'cuda':
         APC_model.cuda() 
     APC_model.eval()


### PR DESCRIPTION
I got this error:
" If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU. "

[https://pytorch.org/docs/stable/generated/torch.load.html](url)

when trying with this command:
`python demo.py --id May --driving_audio ./data/Input/00083.wav --device cp`

Explicitly adding this works:
map_location=device

I am not able to try this on CUDA. Please check if this works on CUDA.